### PR TITLE
Make lint fix build failure optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,8 +155,8 @@ Options are configured in the `kotlinter` extension. Defaults shown (you may omi
 
 ```kotlin
 kotlinter {
-    ignoreFailures = false
     failBuildWhenCannotAutoFormat = false
+    ignoreFailures = false
     reporters = arrayOf("checkstyle", "plain")
 }
 ```
@@ -168,8 +168,8 @@ kotlinter {
 
 ```groovy
 kotlinter {
-    ignoreFailures = false
     failBuildWhenCannotAutoFormat = false
+    ignoreFailures = false
     reporters = ['checkstyle', 'plain']
 }
 ```

--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Options are configured in the `kotlinter` extension. Defaults shown (you may omi
 ```kotlin
 kotlinter {
     ignoreFailures = false
+    failBuildWhenCannotAutoFormat = false
     reporters = arrayOf("checkstyle", "plain")
 }
 ```
@@ -168,11 +169,13 @@ kotlinter {
 ```groovy
 kotlinter {
     ignoreFailures = false
+    failBuildWhenCannotAutoFormat = false
     reporters = ['checkstyle', 'plain']
 }
 ```
 
 </details>
+Setting `failBuildWhenCannotAutoFormat` to `true` will configure the `formatKotlin` task to fail the build when auto-format is not able to fix a lint error.
 
 Options for `reporters`: `checkstyle`, `html`, `json`, `plain`, `sarif`
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,8 @@ kotlinter {
 ```
 
 </details>
-Setting `failBuildWhenCannotAutoFormat` to `true` will configure the `formatKotlin` task to fail the build when auto-format is not able to fix a lint error.
+
+Setting `failBuildWhenCannotAutoFormat` to `true` will configure the `formatKotlin` task to fail the build when auto-format is not able to fix a lint error. This is overrided by setting `ignoreFailures` to `true`.
 
 Options for `reporters`: `checkstyle`, `html`, `json`, `plain`, `sarif`
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${Versions.junit}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${Versions.junit}")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:${Versions.junit}")
     testImplementation("commons-io:commons-io:2.12.0")
     testImplementation("org.mockito.kotlin:mockito-kotlin:${Versions.mockitoKotlin}")
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
@@ -4,12 +4,12 @@ import org.jmailen.gradle.kotlinter.support.ReporterType
 
 open class KotlinterExtension {
     companion object {
-        const val DEFAULT_IGNORE_FAILURES = false
         const val DEFAULT_FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT = false
+        const val DEFAULT_IGNORE_FAILURES = false
         val DEFAULT_REPORTER = ReporterType.checkstyle.name
     }
 
-    var ignoreFailures = DEFAULT_IGNORE_FAILURES
     var failBuildWhenCannotAutoFormat = DEFAULT_FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT
+    var ignoreFailures = DEFAULT_IGNORE_FAILURES
     var reporters = arrayOf(DEFAULT_REPORTER)
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterExtension.kt
@@ -5,10 +5,11 @@ import org.jmailen.gradle.kotlinter.support.ReporterType
 open class KotlinterExtension {
     companion object {
         const val DEFAULT_IGNORE_FAILURES = false
+        const val DEFAULT_FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT = false
         val DEFAULT_REPORTER = ReporterType.checkstyle.name
     }
 
     var ignoreFailures = DEFAULT_IGNORE_FAILURES
-
+    var failBuildWhenCannotAutoFormat = DEFAULT_FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT
     var reporters = arrayOf(DEFAULT_REPORTER)
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -59,8 +59,8 @@ class KotlinterPlugin : Plugin<Project> {
                         FormatTask::class.java,
                     ) { formatTask ->
                         formatTask.source(resolvedSources)
-                        formatTask.ignoreFailures.set(provider { kotlinterExtension.ignoreFailures })
                         formatTask.failBuildWhenCannotAutoFormat.set(provider { kotlinterExtension.failBuildWhenCannotAutoFormat })
+                        formatTask.ignoreFailures.set(provider { kotlinterExtension.ignoreFailures })
                         formatTask.report.set(reportFile("$id-format.txt"))
                     }
                     formatKotlin.configure { formatTask ->

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/KotlinterPlugin.kt
@@ -59,6 +59,8 @@ class KotlinterPlugin : Plugin<Project> {
                         FormatTask::class.java,
                     ) { formatTask ->
                         formatTask.source(resolvedSources)
+                        formatTask.ignoreFailures.set(provider { kotlinterExtension.ignoreFailures })
+                        formatTask.failBuildWhenCannotAutoFormat.set(provider { kotlinterExtension.failBuildWhenCannotAutoFormat })
                         formatTask.report.set(reportFile("$id-format.txt"))
                     }
                     formatKotlin.configure { formatTask ->

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
@@ -34,6 +34,9 @@ open class FormatTask @Inject constructor(
     @Input
     val ignoreFailures: Property<Boolean> = objectFactory.property(default = KotlinterExtension.DEFAULT_IGNORE_FAILURES)
 
+    @Input
+    val failBuildWhenCannotAutoFormat: Property<Boolean> = objectFactory.property(default = KotlinterExtension.DEFAULT_FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT)
+
     init {
         outputs.upToDateWhen { false }
     }
@@ -56,9 +59,11 @@ open class FormatTask @Inject constructor(
             throw GradleException("error formatting sources for $name")
         }
 
-        val lintFailures = result.exceptionOrNull()?.workErrorCauses<LintFailure>() ?: emptyList()
-        if (lintFailures.isNotEmpty() && !ignoreFailures.get()) {
-            throw GradleException("$name sources failed lint check")
+        if (failBuildWhenCannotAutoFormat.get()) {
+            val lintFailures = result.exceptionOrNull()?.workErrorCauses<LintFailure>() ?: emptyList()
+            if (lintFailures.isNotEmpty() && !ignoreFailures.get()) {
+                throw GradleException("$name sources failed lint check")
+            }
         }
     }
 }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/FormatTask.kt
@@ -35,7 +35,9 @@ open class FormatTask @Inject constructor(
     val ignoreFailures: Property<Boolean> = objectFactory.property(default = KotlinterExtension.DEFAULT_IGNORE_FAILURES)
 
     @Input
-    val failBuildWhenCannotAutoFormat: Property<Boolean> = objectFactory.property(default = KotlinterExtension.DEFAULT_FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT)
+    val failBuildWhenCannotAutoFormat: Property<Boolean> = objectFactory.property(
+        default = KotlinterExtension.DEFAULT_FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT,
+    )
 
     init {
         outputs.upToDateWhen { false }

--- a/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
+++ b/src/main/kotlin/org/jmailen/gradle/kotlinter/tasks/format/FormatWorkerAction.kt
@@ -50,7 +50,7 @@ abstract class FormatWorkerAction : WorkAction<FormatWorkerParameters> {
                         logger.warn(msg)
                     } else {
                         hasError = true
-                        logger.error(msg) // TODO: is this needed?
+                        logger.error(msg)
                     }
                     fixes.add(msg)
                 }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
@@ -28,6 +28,17 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
                             id 'org.jmailen.kotlinter'
                         }
                         """.trimIndent()
+                    KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT ->
+                        """
+                        plugins {
+                            id 'org.jetbrains.kotlin.js'
+                            id 'org.jmailen.kotlinter'
+                        }
+
+                        kotlinter {
+                            failBuildWhenCannotAutoFormat = true
+                        }
+                        """.trimIndent()
                     KotlinterConfig.IGNORE_FAILURES ->
                         """
                         plugins {
@@ -37,17 +48,6 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
 
                         kotlinter {
                             ignoreFailures = true
-                            failBuildWhenCannotAutoFormat = true
-                        }
-                        """.trimIndent()
-                    KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT ->
-                        """
-                        plugins {
-                            id 'org.jetbrains.kotlin.js'
-                            id 'org.jmailen.kotlinter'
-                        }
-
-                        kotlinter {
                             failBuildWhenCannotAutoFormat = true
                         }
                         """.trimIndent()

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
@@ -24,11 +24,14 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
                 // language=groovy
                 val buildScript =
                     """
-                plugins {
-                    id 'kotlin'
-                    id 'org.jmailen.kotlinter'
-                }
-                
+                    plugins {
+                        id 'kotlin'
+                        id 'org.jmailen.kotlinter'
+                    }
+                    
+                    kotlinter {
+                        failBuildWhenCannotAutoFormat = true
+                    }
                     """.trimIndent()
                 writeText(buildScript)
             }
@@ -147,6 +150,38 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
 
     @Test
     fun `editorconfig changes are ignored for format task re-runs`() {
+        projectRoot.resolve(".editorconfig") {
+            writeText(editorConfig)
+        }
+
+        projectRoot.resolve("src/main/kotlin/FileName.kt") {
+            writeText(kotlinClass("DifferentClassName"))
+        }
+        build("formatKotlin").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":formatKotlinMain")?.outcome)
+            assertTrue(
+                output.contains("Format could not fix > [standard:filename] File 'FileName.kt' contains a single top level declaration"),
+            )
+        }
+
+        projectRoot.resolve(".editorconfig") {
+            writeText(
+                // language=editorconfig
+                """
+                    [*.{kt,kts}]
+                    ktlint_standard_filename = disabled
+                """.trimIndent(),
+            )
+        }
+        build("formatKotlin", "--info").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":formatKotlinMain")?.outcome)
+            assertTrue(output.contains("Format could not fix"))
+            assertFalse(output.contains("resetting KtLint caches"))
+        }
+    }
+
+    @Test
+    fun `editorconfig changes are ignored for format task re-runs when failBuildWhenCannotAutoFormat enabled`() {
         projectRoot.resolve(".editorconfig") {
             writeText(editorConfig)
         }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/EditorConfigTest.kt
@@ -1,6 +1,7 @@
 package org.jmailen.gradle.kotlinter.functional
 
 import org.gradle.testkit.runner.TaskOutcome
+import org.jmailen.gradle.kotlinter.functional.utils.KotlinterConfig
 import org.jmailen.gradle.kotlinter.functional.utils.editorConfig
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
@@ -8,7 +9,6 @@ import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.io.File
 
@@ -16,30 +16,50 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
 
     lateinit var projectRoot: File
 
-    @BeforeEach
-    fun setUp() {
+    private fun setup(kotlinterConfig: KotlinterConfig) {
         projectRoot = testProjectDir.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
-                // language=groovy
-                val buildScript =
-                    """
-                    plugins {
-                        id 'kotlin'
-                        id 'org.jmailen.kotlinter'
-                    }
-                    
-                    kotlinter {
-                        failBuildWhenCannotAutoFormat = true
-                    }
-                    """.trimIndent()
-                writeText(buildScript)
+                val buildscript = when (kotlinterConfig) {
+                    KotlinterConfig.DEFAULT ->
+                        """
+                        plugins {
+                            id 'kotlin'
+                            id 'org.jmailen.kotlinter'
+                        }
+                        """.trimIndent()
+                    KotlinterConfig.IGNORE_FAILURES ->
+                        """
+                        plugins {
+                            id 'org.jetbrains.kotlin.js'
+                            id 'org.jmailen.kotlinter'
+                        }
+
+                        kotlinter {
+                            ignoreFailures = true
+                            failBuildWhenCannotAutoFormat = true
+                        }
+                        """.trimIndent()
+                    KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT ->
+                        """
+                        plugins {
+                            id 'org.jetbrains.kotlin.js'
+                            id 'org.jmailen.kotlinter'
+                        }
+
+                        kotlinter {
+                            failBuildWhenCannotAutoFormat = true
+                        }
+                        """.trimIndent()
+                }
+                writeText(buildscript)
             }
         }
     }
 
     @Test
     fun `lintTask uses default indentation if editorconfig absent`() {
+        setup(KotlinterConfig.DEFAULT)
         projectRoot.resolve("src/main/kotlin/FourSpacesByDefault.kt") {
             writeText(
                 """ |
@@ -58,6 +78,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
 
     @Test
     fun `plugin respects disabled_rules set in editorconfig`() {
+        setup(KotlinterConfig.DEFAULT)
         projectRoot.resolve(".editorconfig") {
             appendText(
                 // language=editorconfig
@@ -78,6 +99,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
 
     @Test
     fun `plugin respects 'indent_size' set in editorconfig`() {
+        setup(KotlinterConfig.DEFAULT)
         projectRoot.resolve(".editorconfig") {
             appendText(
                 // language=editorconfig
@@ -109,6 +131,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
 
     @Test
     fun `editorconfig changes are taken into account on lint task re-runs`() {
+        setup(KotlinterConfig.DEFAULT)
         projectRoot.resolve(".editorconfig") {
             writeText(
                 // language=editorconfig
@@ -150,6 +173,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
 
     @Test
     fun `editorconfig changes are ignored for format task re-runs`() {
+        setup(KotlinterConfig.DEFAULT)
         projectRoot.resolve(".editorconfig") {
             writeText(editorConfig)
         }
@@ -182,6 +206,7 @@ internal class EditorConfigTest : WithGradleTest.Kotlin() {
 
     @Test
     fun `editorconfig changes are ignored for format task re-runs when failBuildWhenCannotAutoFormat enabled`() {
+        setup(KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT)
         projectRoot.resolve(".editorconfig") {
             writeText(editorConfig)
         }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinJsProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinJsProjectTest.kt
@@ -1,6 +1,7 @@
 package org.jmailen.gradle.kotlinter.functional
 
 import org.gradle.testkit.runner.TaskOutcome
+import org.jmailen.gradle.kotlinter.functional.utils.KotlinterConfig
 import org.jmailen.gradle.kotlinter.functional.utils.kotlinClass
 import org.jmailen.gradle.kotlinter.functional.utils.resolve
 import org.jmailen.gradle.kotlinter.functional.utils.settingsFile
@@ -9,19 +10,14 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
 class KotlinJsProjectTest : WithGradleTest.Kotlin() {
-    enum class KotlinterConfig {
-        DEFAULT,
-        IGNORE_FAILURES,
-        FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT,
-    }
 
     lateinit var projectRoot: File
-    fun setup(kotlinterConfig: KotlinterConfig) {
+    private fun setup(kotlinterConfig: KotlinterConfig) {
         projectRoot = testProjectDir.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
-                when (kotlinterConfig) {
-                    KotlinterConfig.DEFAULT -> writeText(
+                val buildscript = when (kotlinterConfig) {
+                    KotlinterConfig.DEFAULT ->
                         """
                         plugins {
                             id 'org.jetbrains.kotlin.js'
@@ -36,9 +32,8 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
                                 binaries.executable()
                             }
                         }
-                        """.trimIndent(),
-                    )
-                    KotlinterConfig.IGNORE_FAILURES -> writeText(
+                        """.trimIndent()
+                    KotlinterConfig.IGNORE_FAILURES ->
                         """
                         plugins {
                             id 'org.jetbrains.kotlin.js'
@@ -58,9 +53,8 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
                             ignoreFailures = true
                             failBuildWhenCannotAutoFormat = true
                         }
-                        """.trimIndent(),
-                    )
-                    KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT -> writeText(
+                        """.trimIndent()
+                    KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT ->
                         """
                         plugins {
                             id 'org.jetbrains.kotlin.js'
@@ -79,9 +73,9 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
                         kotlinter {
                             failBuildWhenCannotAutoFormat = true
                         }
-                        """.trimIndent(),
-                    )
+                        """.trimIndent()
                 }
+                writeText(buildscript)
             }
         }
     }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinJsProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinJsProjectTest.kt
@@ -8,13 +8,11 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.io.File
-
-
 class KotlinJsProjectTest : WithGradleTest.Kotlin() {
     enum class KotlinterConfig {
         DEFAULT,
         IGNORE_FAILURES,
-        FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT
+        FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT,
     }
 
     lateinit var projectRoot: File
@@ -22,66 +20,66 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
         projectRoot = testProjectDir.apply {
             resolve("settings.gradle") { writeText(settingsFile) }
             resolve("build.gradle") {
-                when(kotlinterConfig){
+                when (kotlinterConfig) {
                     KotlinterConfig.DEFAULT -> writeText(
                         """
-                    plugins {
-                        id 'org.jetbrains.kotlin.js'
-                        id 'org.jmailen.kotlinter'
-                    }
-
-                    repositories.mavenCentral()
-
-                    kotlin {
-                        js(IR) {
-                            browser()
-                            binaries.executable()
+                        plugins {
+                            id 'org.jetbrains.kotlin.js'
+                            id 'org.jmailen.kotlinter'
                         }
-                    }
-                    """.trimIndent(),
+    
+                        repositories.mavenCentral()
+    
+                        kotlin {
+                            js(IR) {
+                                browser()
+                                binaries.executable()
+                            }
+                        }
+                        """.trimIndent(),
                     )
                     KotlinterConfig.IGNORE_FAILURES -> writeText(
                         """
-                    plugins {
-                        id 'org.jetbrains.kotlin.js'
-                        id 'org.jmailen.kotlinter'
-                    }
-
-                    repositories.mavenCentral()
-
-                    kotlin {
-                        js(IR) {
-                            browser()
-                            binaries.executable()
+                        plugins {
+                            id 'org.jetbrains.kotlin.js'
+                            id 'org.jmailen.kotlinter'
                         }
-                    }
-                    
-                    kotlinter {
-                        ignoreFailures = true
-                        failBuildWhenCannotAutoFormat = true
-                    }
-                    """.trimIndent(),
+    
+                        repositories.mavenCentral()
+    
+                        kotlin {
+                            js(IR) {
+                                browser()
+                                binaries.executable()
+                            }
+                        }
+                        
+                        kotlinter {
+                            ignoreFailures = true
+                            failBuildWhenCannotAutoFormat = true
+                        }
+                        """.trimIndent(),
                     )
                     KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT -> writeText(
                         """
-                    plugins {
-                        id 'org.jetbrains.kotlin.js'
-                        id 'org.jmailen.kotlinter'
-                    }
-
-                    repositories.mavenCentral()
-
-                    kotlin {
-                        js(IR) {
-                            browser()
-                            binaries.executable()
+                        plugins {
+                            id 'org.jetbrains.kotlin.js'
+                            id 'org.jmailen.kotlinter'
                         }
-                    }
-                    
-                    kotlinter {
-                        failBuildWhenCannotAutoFormat = true
-                    }
-                    """.trimIndent(),
+    
+                        repositories.mavenCentral()
+    
+                        kotlin {
+                            js(IR) {
+                                browser()
+                                binaries.executable()
+                            }
+                        }
+                        
+                        kotlinter {
+                            failBuildWhenCannotAutoFormat = true
+                        }
+                        """.trimIndent(),
                     )
                 }
             }
@@ -209,7 +207,7 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
     }
 
     @Test
-    fun `formatKotlin fails reports formatted and unformatted files when ignoreFailures and failBuildWhenCannotAutoFormat enabled`() {
+    fun `formatKotlin fails when lint errors not automatically fixed and failBuildWhenCannotAutoFormat enabled `() {
         setup(KotlinterConfig.IGNORE_FAILURES)
         projectRoot.resolve("src/main/kotlin/FixtureClass.kt") {
             // language=kotlin
@@ -248,5 +246,4 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
             assertTrue(output.contains("FixtureTestClass.kt:1:1: Format could not fix > [standard:no-wildcard-imports] Wildcard import"))
         }
     }
-
 }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinJsProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinJsProjectTest.kt
@@ -33,6 +33,26 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
                             }
                         }
                         """.trimIndent()
+                    KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT ->
+                        """
+                        plugins {
+                            id 'org.jetbrains.kotlin.js'
+                            id 'org.jmailen.kotlinter'
+                        }
+    
+                        repositories.mavenCentral()
+    
+                        kotlin {
+                            js(IR) {
+                                browser()
+                                binaries.executable()
+                            }
+                        }
+                        
+                        kotlinter {
+                            failBuildWhenCannotAutoFormat = true
+                        }
+                        """.trimIndent()
                     KotlinterConfig.IGNORE_FAILURES ->
                         """
                         plugins {
@@ -51,26 +71,6 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
                         
                         kotlinter {
                             ignoreFailures = true
-                            failBuildWhenCannotAutoFormat = true
-                        }
-                        """.trimIndent()
-                    KotlinterConfig.FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT ->
-                        """
-                        plugins {
-                            id 'org.jetbrains.kotlin.js'
-                            id 'org.jmailen.kotlinter'
-                        }
-    
-                        repositories.mavenCentral()
-    
-                        kotlin {
-                            js(IR) {
-                                browser()
-                                binaries.executable()
-                            }
-                        }
-                        
-                        kotlinter {
                             failBuildWhenCannotAutoFormat = true
                         }
                         """.trimIndent()
@@ -201,7 +201,7 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
     }
 
     @Test
-    fun `formatKotlin fails when lint errors not automatically fixed and failBuildWhenCannotAutoFormat enabled `() {
+    fun `formatKotlin reports formatted and unformatted files when failBuildWhenCannotAutoFormat and ignoreFailures enabled`() {
         setup(KotlinterConfig.IGNORE_FAILURES)
         projectRoot.resolve("src/main/kotlin/FixtureClass.kt") {
             // language=kotlin

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinJsProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinJsProjectTest.kt
@@ -11,14 +11,11 @@ import java.io.File
 
 
 class KotlinJsProjectTest : WithGradleTest.Kotlin() {
-
-
     enum class KotlinterConfig {
         DEFAULT,
         IGNORE_FAILURES,
         FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT
     }
-
 
     lateinit var projectRoot: File
     fun setup(kotlinterConfig: KotlinterConfig) {
@@ -206,6 +203,47 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
             assertTrue(output.contains("FixtureClass.kt:3:19: Format fixed > [standard:curly-spacing] Missing spacing before \"{\""))
             assertTrue(output.contains("FixtureClass.kt:1:1: Format could not fix > [standard:no-wildcard-imports] Wildcard import"))
             assertEquals(TaskOutcome.FAILED, task(":formatKotlinTest")?.outcome)
+            assertTrue(output.contains("FixtureTestClass.kt:3:23: Format fixed > [standard:curly-spacing] Missing spacing before \"{\""))
+            assertTrue(output.contains("FixtureTestClass.kt:1:1: Format could not fix > [standard:no-wildcard-imports] Wildcard import"))
+        }
+    }
+
+    @Test
+    fun `formatKotlin fails reports formatted and unformatted files when ignoreFailures and failBuildWhenCannotAutoFormat enabled`() {
+        setup(KotlinterConfig.IGNORE_FAILURES)
+        projectRoot.resolve("src/main/kotlin/FixtureClass.kt") {
+            // language=kotlin
+            val kotlinClass =
+                """
+                import System.*
+                
+                class FixtureClass{
+                    private fun hi() {
+                        out.println("Hello")
+                    }
+                }
+                """.trimIndent()
+            writeText(kotlinClass)
+        }
+        projectRoot.resolve("src/test/kotlin/FixtureTestClass.kt") {
+            // language=kotlin
+            val kotlinClass =
+                """
+                import System.*
+                
+                class FixtureTestClass{
+                    private fun hi() {
+                        out.println("Hello")
+                    }
+                }
+                """.trimIndent()
+            writeText(kotlinClass)
+        }
+        build("formatKotlin").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":formatKotlinMain")?.outcome)
+            assertTrue(output.contains("FixtureClass.kt:3:19: Format fixed > [standard:curly-spacing] Missing spacing before \"{\""))
+            assertTrue(output.contains("FixtureClass.kt:1:1: Format could not fix > [standard:no-wildcard-imports] Wildcard import"))
+            assertEquals(TaskOutcome.SUCCESS, task(":formatKotlinTest")?.outcome)
             assertTrue(output.contains("FixtureTestClass.kt:3:23: Format fixed > [standard:curly-spacing] Missing spacing before \"{\""))
             assertTrue(output.contains("FixtureTestClass.kt:1:1: Format could not fix > [standard:no-wildcard-imports] Wildcard import"))
         }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinJsProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinJsProjectTest.kt
@@ -107,6 +107,46 @@ class KotlinJsProjectTest : WithGradleTest.Kotlin() {
                 """.trimIndent()
             writeText(kotlinClass)
         }
+        build("formatKotlin").apply {
+            assertEquals(TaskOutcome.SUCCESS, task(":formatKotlinMain")?.outcome)
+            assertTrue(output.contains("FixtureClass.kt:3:19: Format fixed > [standard:curly-spacing] Missing spacing before \"{\""))
+            assertTrue(output.contains("FixtureClass.kt:1:1: Format could not fix > [standard:no-wildcard-imports] Wildcard import"))
+            assertEquals(TaskOutcome.SUCCESS, task(":formatKotlinTest")?.outcome)
+            assertTrue(output.contains("FixtureTestClass.kt:3:23: Format fixed > [standard:curly-spacing] Missing spacing before \"{\""))
+            assertTrue(output.contains("FixtureTestClass.kt:1:1: Format could not fix > [standard:no-wildcard-imports] Wildcard import"))
+        }
+    }
+
+    @Test
+    fun `formatKotlin fails when lint errors not automatically fixed and failBuildWhenCannotAutoFormat enabled`() {
+        projectRoot.resolve("src/main/kotlin/FixtureClass.kt") {
+            // language=kotlin
+            val kotlinClass =
+                """
+                import System.*
+                
+                class FixtureClass{
+                    private fun hi() {
+                        out.println("Hello")
+                    }
+                }
+                """.trimIndent()
+            writeText(kotlinClass)
+        }
+        projectRoot.resolve("src/test/kotlin/FixtureTestClass.kt") {
+            // language=kotlin
+            val kotlinClass =
+                """
+                import System.*
+                
+                class FixtureTestClass{
+                    private fun hi() {
+                        out.println("Hello")
+                    }
+                }
+                """.trimIndent()
+            writeText(kotlinClass)
+        }
         buildAndFail("formatKotlin").apply {
             assertEquals(TaskOutcome.FAILED, task(":formatKotlinMain")?.outcome)
             assertTrue(output.contains("FixtureClass.kt:3:19: Format fixed > [standard:curly-spacing] Missing spacing before \"{\""))

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
@@ -129,7 +129,7 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
     }
 
     @Test
-    fun `formatKotlin fails reports formatted and unformatted files when ignoreFailures and failBuildWhenCannotAutoFormat enabled`() {
+    fun `formatKotlin reports formatted and unformatted files when failBuildWhenCannotAutoFormat and ignoreFailures enabled`() {
         settingsFile()
         buildFileIgnoreFailures()
         // language=kotlin

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/KotlinProjectTest.kt
@@ -77,33 +77,7 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
     }
 
     @Test
-    fun `formatKotlin fails reports formatted and unformatted files when ignoreFailures and failBuildWhenCannotAutoFormat enabled`() {
-        settingsFile()
-        buildFileIgnoreFailures()
-        // language=kotlin
-        val kotlinClass =
-            """
-            import System.*
-            
-            class KotlinClass{
-                private fun hi() {
-                    out.println("Hello")
-                }
-            }
-            """.trimIndent()
-        kotlinSourceFile("KotlinClass.kt", kotlinClass)
-
-        build("formatKotlin").apply {
-            assertEquals(SUCCESS, task(":formatKotlinMain")?.outcome)
-            output.lines().filter { it.contains("Format could not fix") }.forEach { line ->
-                val filePath = pathPattern.find(line)?.groups?.get(1)?.value.orEmpty()
-                assertTrue(File(filePath).exists())
-            }
-        }
-    }
-
-    @Test
-    fun `formatKotlin reports formatted and unformatted files when ignoreFailures and failBuildWhenCannotAutoFormat disabled`() {
+    fun `formatKotlin reports formatted and unformatted files`() {
         settingsFile()
         buildFile()
         // language=kotlin
@@ -129,7 +103,7 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
     }
 
     @Test
-    fun `formatKotlin fails when lint errors not automatically fixed when ignoreFailures disabled and failBuildWhenCannotAutoFormat enabled`() {
+    fun `formatKotlin fails when lint errors not automatically fixed and failBuildWhenCannotAutoFormat enabled`() {
         settingsFile()
         buildFileFailBuildWhenCannotAutoFormat()
         // language=kotlin
@@ -154,7 +128,31 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
         }
     }
 
+    @Test
+    fun `formatKotlin fails reports formatted and unformatted files when ignoreFailures and failBuildWhenCannotAutoFormat enabled`() {
+        settingsFile()
+        buildFileIgnoreFailures()
+        // language=kotlin
+        val kotlinClass =
+            """
+            import System.*
+            
+            class KotlinClass{
+                private fun hi() {
+                    out.println("Hello")
+                }
+            }
+            """.trimIndent()
+        kotlinSourceFile("KotlinClass.kt", kotlinClass)
 
+        build("formatKotlin").apply {
+            assertEquals(SUCCESS, task(":formatKotlinMain")?.outcome)
+            output.lines().filter { it.contains("Format could not fix") }.forEach { line ->
+                val filePath = pathPattern.find(line)?.groups?.get(1)?.value.orEmpty()
+                assertTrue(File(filePath).exists())
+            }
+        }
+    }
 
     @Test
     fun `check task runs lintFormat`() {
@@ -278,7 +276,6 @@ internal class KotlinProjectTest : WithGradleTest.Kotlin() {
             }
             
             kotlinter {
-                ignoreFailures = false
                 failBuildWhenCannotAutoFormat = true
             }
             """.trimIndent()

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/KotlinterConfig.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/KotlinterConfig.kt
@@ -2,6 +2,6 @@ package org.jmailen.gradle.kotlinter.functional.utils
 
 enum class KotlinterConfig {
     DEFAULT,
-    IGNORE_FAILURES,
     FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT,
+    IGNORE_FAILURES
 }

--- a/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/KotlinterConfig.kt
+++ b/src/test/kotlin/org/jmailen/gradle/kotlinter/functional/utils/KotlinterConfig.kt
@@ -1,0 +1,7 @@
+package org.jmailen.gradle.kotlinter.functional.utils
+
+enum class KotlinterConfig {
+    DEFAULT,
+    IGNORE_FAILURES,
+    FAIL_BUILD_WHEN_CANNOT_AUTO_FORMAT,
+}


### PR DESCRIPTION
The master branch already has the logic we added to make `formatKotlin` task fail
>- We followed the logic the `lintKotlin` task uses when it fails the build: For each lint error that cannot be autoformatted, log an error and throw `LintFailure` exception, which will ultimately cause `GradleException` to be thrown
>- We can go through these changes on a call if that would be easier

Please review this PR containing the logic to make the build failure optional, especially the drastic changes we made to the test setup
>- KotlinTestProject.kt: added `buildFileFailBuildWhenCannotAutoFormat()` and `buildFileIgnoreFailures()`
>- KotlintJsTestProject.kt & EditorConfig.kt: changed `setup()` from a `@BeforeEach` to a function called at the beginning of each test function with a parameter representing the `kotlinter` configuration needed for that test case

We would appreciate any feedback to help improve the likelihood of our changes being approved by the original repo maintainers